### PR TITLE
Fix: Title translation doesn't match which id is after 744.

### DIFF
--- a/plugins/leetcode.cn.js
+++ b/plugins/leetcode.cn.js
@@ -74,7 +74,7 @@ plugin.getProblems = function(cb) {
       if (e) return cb(e);
 
       problems.forEach(function(problem) {
-        const title = titles[problem.fid];
+        const title = titles[problem.id];
         if (title)
           problem.name = title;
       });


### PR DESCRIPTION
Question id is no longer equal to fid which id is after 744. 
So the translation doesn't match after 744.
Using 'fid' to find translation instead.
