### PR TITLE
Fix leetcode.cn plugin http 400 error

### DIFF
--- a/plugins/leetcode.cn.js
+++ b/plugins/leetcode.cn.js
@@ -77,6 +77,7 @@ plugin.getProblems = function(cb) {
         const title = titles[problem.fid];
         if (title)
           problem.name = title;
+        problem.fid = Number(problem.fid) || problem.fid
       });
 
       return cb(null, problems);
@@ -97,12 +98,11 @@ plugin.getProblemsTitle = function(cb) {
       'query getQuestionTranslation($lang: String) {',
       '  translations: allAppliedQuestionTranslations(lang: $lang) {',
       '    title',
-      '    question {',
-      '      questionId',
-      '    }',
+      '    questionId',
+      '    __typename',
       '  }',
       '}',
-      ''
+      '',
     ].join('\n'),
     variables:     {},
     operationName: 'getQuestionTranslation'
@@ -116,7 +116,7 @@ plugin.getProblemsTitle = function(cb) {
 
     const titles = [];
     body.data.translations.forEach(function(x) {
-      titles[x.question.questionId] = x.title;
+      titles[x.questionId] = x.title;
     });
 
     return cb(null, titles);


### PR DESCRIPTION
- leetcode-cn.com graphql API for `query getQuestionTranslation` has changed.
- `problem.fid` should be converted to Nubmer so that `leetcode-cli show` command can work without changing any code.
