### PR TITLE
Fix cookie.chrome on KDE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,69 @@
+{
+  "name": "leetcode-cli-plugins",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "desktop-env": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/desktop-env/-/desktop-env-3.0.1.tgz",
+      "integrity": "sha512-B+irbijyrWK9v0Ivu05A9vjS4BiNY97w/4nv0DQNa+NERoB9R9iKHZsLrTvufPTMvuRJ0n5qkn0ZDtJcQ+fgrg==",
+      "requires": {
+        "is-cinnamon": "^3.0.0",
+        "is-gnome": "^4.0.0",
+        "is-kde": "^4.0.0",
+        "is-lxde": "^4.0.0",
+        "is-mate": "^4.0.0",
+        "is-sugar": "^4.0.0",
+        "is-unity": "^4.0.0",
+        "is-xfce": "^4.0.0",
+        "pify": "^4.0.0"
+      }
+    },
+    "is-cinnamon": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-cinnamon/-/is-cinnamon-3.0.0.tgz",
+      "integrity": "sha512-qR2Cu5N0Gdu5adcGKDpEEcVFrygPWQGjqBtTjraxd3f1L+sRwf+JYjXgkPH3Hn33L3f7hzJDpEVB9Qf/IQ16Lg=="
+    },
+    "is-gnome": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-gnome/-/is-gnome-4.0.0.tgz",
+      "integrity": "sha512-2Nnl8IgE6cgMwPs0xMKdjgGMUe1IxBaTAvdTHbaqy65bdj9Qw7t236yAKWeAgjZo7Iiv9gMhwnOkTrebyZ+l/A=="
+    },
+    "is-kde": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-kde/-/is-kde-4.0.0.tgz",
+      "integrity": "sha512-CUBxdQL0UuUJWV5h1erHu9FS/4dzs+x16A2O2X0DYnrOu/zk8GNs6ucIl+GGq0+XJvYPYs/L6zH2bwa723cwtA=="
+    },
+    "is-lxde": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-lxde/-/is-lxde-4.0.0.tgz",
+      "integrity": "sha512-U030agjYMmwdUXWDLGSgMmySK8q4tLEhvkcYWQhyYmVeHHf0nYVexW7UkfAk2OBz/wjNHzbetDGDm8t5au9YKQ=="
+    },
+    "is-mate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-mate/-/is-mate-4.0.0.tgz",
+      "integrity": "sha512-VgK//HC2B2bl4/vFPNSz79PZz2gQ1UX58i16J40uB2cnptIyFs5mGAP24sEaybZUSPv/hLAQTURsKyUrIfENsA=="
+    },
+    "is-sugar": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-sugar/-/is-sugar-4.0.0.tgz",
+      "integrity": "sha512-fx9zMF8dhaFiKSoyfLM8VDOLP+byZh7yKYT7jNAK+qGrmYYTyALH8tjn/z438qMGOrqVcs6vDLXH0P1nxRmGbQ=="
+    },
+    "is-unity": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-unity/-/is-unity-4.0.0.tgz",
+      "integrity": "sha512-i0k026WPLxFxBfqKersnC0HlWBIdSjmdZCQBBlWW8Nd1ZZnAV9qtg1No7Fg9EnFhgyFJYMfM84chLR+DBrVbuQ=="
+    },
+    "is-xfce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-xfce/-/is-xfce-4.0.0.tgz",
+      "integrity": "sha512-CwI9HoMRx9WZieb7Zt4N2Czcyx9gY9I99vBijsNED+m5Rq/B+2x/s1yOIb4ayiAGBy9zH5ZEeskftWpJdO1mfA=="
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "devDependencies": {
     "eslint": "5.9.0",
     "eslint-config-google": "0.11.0"
+  },
+  "dependencies": {
+    "desktop-env": "^3.0.1"
   }
 }

--- a/plugins/cookie.chrome.js
+++ b/plugins/cookie.chrome.js
@@ -4,6 +4,7 @@ var log = require('../log');
 var Plugin = require('../plugin');
 var Queue = require('../queue');
 var session = require('../session');
+const GetLinuxDesktopEnv = require('desktop-env');
 
 // [Usage]
 //
@@ -42,11 +43,18 @@ var ChromeLinux = {
   getDBPath: function() {
     return `${process.env.HOME}/.config/google-chrome/${this.profile}/Cookies`;
   },
-  iterations:  1,
-  getPassword: function(cb) {
+  iterations: 1,
+  getPassword: async function (cb) {
     // FIXME: keytar failed to read gnome-keyring on ubuntu??
-    var cmd = 'secret-tool lookup application chrome';
-    var password = require('child_process').execSync(cmd).toString();
+    var cmd = '';
+    switch (await GetLinuxDesktopEnv()) {
+      case "KDE":
+        cmd = 'kwallet-query -r "Chrome Safe Storage" -f "Chrome Keys"  kdewallet';
+        break;
+      default:
+        cmd = 'secret-tool lookup application chrome';
+    }
+    var password = require('child_process').execSync(cmd).toString().trim();
     return cb(password);
   }
 };


### PR DESCRIPTION
`secret-tool` doesn't work on all flavors of Ubuntu. Chrome on Kubuntu uses `kwallet`.

Added a switch statement that changes the command required to get the password based on the Linux Desktop Environment.